### PR TITLE
Modified sqlite3_wrapper.c to make compilable with i686-pc-mingw32-gcc

### DIFF
--- a/sqlite3_wrapper.c
+++ b/sqlite3_wrapper.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #define WINVER 0x0501
+#define _WIN32_WINNT 0x0501
 #include <windef.h>
 #include <windows.h>
 #include <shlobj.h>


### PR DESCRIPTION
- To avoid the following linkage error:
  
  ```
  sqlite3_wrapper.o:sqlite3_wrapper.c:(.text+0x9a): undefined reference to `SHGetFolderPathAndSubDir'
  ```
